### PR TITLE
Add message about containers not spun up if ports is empty array

### DIFF
--- a/lib/spurious/ruby/awssdk/strategy.rb
+++ b/lib/spurious/ruby/awssdk/strategy.rb
@@ -43,6 +43,7 @@ module Spurious
         def apply(config)
           mapping.each do |type, mappings|
             ports = config[type]
+            if ports == [] then raise "It looks like the containers are not spun up." end
             AWS.config("#{mappings['identifier']}_port".to_sym => ports.first['HostPort']) if mappings['port']
             AWS.config("#{mappings['identifier']}_endpoint".to_sym => ports.first['Host']) if mappings['ip']
           end


### PR DESCRIPTION
Literally just bashed this out with the online editor. Just came across this issue, if it was earlier in the morning I would probably had no clue what was happening, so I added a simple error message for when this occurs.