### PR TITLE
Migrate to v2 AWS-SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Or install it yourself as:
 
     $ gem install spurious-ruby-awssdk-helper
 
+## AWS SDK Versions
+
+- The gem supports using both `~v1` and `~v2` of the `aws-sdk` gem.
+- The gem uses `~v1` before it's `v1.0.0` release.
+- The gem uses `~v2` past it's `v1.0.0+` release.
+
 ## Usage
 
 You can configure the `aws-sdk` two different ways:

--- a/lib/spurious/ruby/awssdk/helper.rb
+++ b/lib/spurious/ruby/awssdk/helper.rb
@@ -52,7 +52,6 @@ module Spurious
           strategy ||= Spurious::Ruby::Awssdk::Strategy.new(true)
           strategy.apply(config(type))
         end
-
       end
     end
   end

--- a/lib/spurious/ruby/awssdk/strategy.rb
+++ b/lib/spurious/ruby/awssdk/strategy.rb
@@ -17,34 +17,34 @@ module Spurious
         end
 
         def dynamo(port = true, ip = true)
-          mapping['spurious-dynamo'] = {
-            'port'       => port,
-            'ip'         => ip,
-            'identifier' => 'dynamo_db'
+          mapping["spurious-dynamo"] = {
+            "port"       => port,
+            "ip"         => ip,
+            "identifier" => "dynamo_db"
           }
         end
 
         def sqs(port = true, ip = true)
-          mapping['spurious-sqs'] = {
-            'port'       => port,
-            'ip'         => ip,
-            'identifier' => 'sqs'
+          mapping["spurious-sqs"] = {
+            "port"       => port,
+            "ip"         => ip,
+            "identifier" => "sqs"
           }
         end
 
         def s3(port = true, ip = true)
-          mapping['spurious-s3'] = {
-            'port'       => port,
-            'ip'         => ip,
-            'identifier' => 's3'
+          mapping["spurious-s3"] = {
+            "port"       => port,
+            "ip"         => ip,
+            "identifier" => "s3"
           }
         end
 
         def apply(config)
           mapping.each do |type, mappings|
             ports = config[type]
-            Aws.config("#{mappings['identifier']}_port".to_sym => ports.first['HostPort']) if mappings['port']
-            Aws.config("#{mappings['identifier']}_endpoint".to_sym => ports.first['Host']) if mappings['ip']
+            Aws.config("#{mappings['identifier']}_port".to_sym => ports.first["HostPort"]) if mappings["port"]
+            Aws.config("#{mappings['identifier']}_endpoint".to_sym => ports.first["Host"]) if mappings["ip"]
           end
 
           Aws.config(:use_ssl => false, :s3_force_path_style => true)

--- a/lib/spurious/ruby/awssdk/strategy.rb
+++ b/lib/spurious/ruby/awssdk/strategy.rb
@@ -5,8 +5,6 @@ module Spurious
   module Ruby
     module Awssdk
       class Strategy
-        attr_accessor :mapping
-
         def initialize(set_all = false)
           @mapping = {}
           return unless set_all
@@ -16,19 +14,25 @@ module Spurious
           s3
         end
 
+        def apply(config)
+          mapping.each do |type, mappings|
+            ports = config[type]
+            Aws.config("#{mappings['identifier']}_port".to_sym => ports.first["HostPort"]) if mappings["port"]
+            Aws.config("#{mappings['identifier']}_endpoint".to_sym => ports.first["Host"]) if mappings["ip"]
+          end
+
+          Aws.config(:use_ssl => false, :s3_force_path_style => true)
+        end
+
+        private
+
+        attr_reader :mapping
+
         def dynamo(port = true, ip = true)
           mapping["spurious-dynamo"] = {
             "port"       => port,
             "ip"         => ip,
             "identifier" => "dynamo_db"
-          }
-        end
-
-        def sqs(port = true, ip = true)
-          mapping["spurious-sqs"] = {
-            "port"       => port,
-            "ip"         => ip,
-            "identifier" => "sqs"
           }
         end
 
@@ -40,14 +44,12 @@ module Spurious
           }
         end
 
-        def apply(config)
-          mapping.each do |type, mappings|
-            ports = config[type]
-            Aws.config("#{mappings['identifier']}_port".to_sym => ports.first["HostPort"]) if mappings["port"]
-            Aws.config("#{mappings['identifier']}_endpoint".to_sym => ports.first["Host"]) if mappings["ip"]
-          end
-
-          Aws.config(:use_ssl => false, :s3_force_path_style => true)
+        def sqs(port = true, ip = true)
+          mapping["spurious-sqs"] = {
+            "port"       => port,
+            "ip"         => ip,
+            "identifier" => "sqs"
+          }
         end
       end
     end

--- a/lib/spurious/ruby/awssdk/strategy.rb
+++ b/lib/spurious/ruby/awssdk/strategy.rb
@@ -17,11 +17,11 @@ module Spurious
         def apply(config)
           mapping.each do |type, mappings|
             ports = config[type]
-            Aws.config("#{mappings['identifier']}_port".to_sym => ports.first["HostPort"]) if mappings["port"]
-            Aws.config("#{mappings['identifier']}_endpoint".to_sym => ports.first["Host"]) if mappings["ip"]
+            Aws.config.update("#{mappings['identifier']}_port".to_sym => ports.first["HostPort"]) if mappings["port"]
+            Aws.config.update("#{mappings['identifier']}_endpoint".to_sym => ports.first["Host"]) if mappings["ip"]
           end
 
-          Aws.config(:use_ssl => false, :s3_force_path_style => true)
+          Aws.config.update(:use_ssl => false, :s3_force_path_style => true)
         end
 
         private

--- a/lib/spurious/ruby/awssdk/strategy.rb
+++ b/lib/spurious/ruby/awssdk/strategy.rb
@@ -9,11 +9,11 @@ module Spurious
 
         def initialize(set_all = false)
           @mapping = {}
-          if set_all then
-            dynamo
-            sqs
-            s3
-          end
+          return unless set_all
+
+          dynamo
+          sqs
+          s3
         end
 
         def dynamo(port = true, ip = true)
@@ -43,14 +43,12 @@ module Spurious
         def apply(config)
           mapping.each do |type, mappings|
             ports = config[type]
-            AWS.config("#{mappings['identifier']}_port".to_sym => ports.first['HostPort']) if mappings['port']
-            AWS.config("#{mappings['identifier']}_endpoint".to_sym => ports.first['Host']) if mappings['ip']
+            Aws.config("#{mappings['identifier']}_port".to_sym => ports.first['HostPort']) if mappings['port']
+            Aws.config("#{mappings['identifier']}_endpoint".to_sym => ports.first['Host']) if mappings['ip']
           end
 
-          AWS.config(:use_ssl => false, :s3_force_path_style => true)
-
+          Aws.config(:use_ssl => false, :s3_force_path_style => true)
         end
-
       end
     end
   end

--- a/lib/spurious/ruby/awssdk/strategy.rb
+++ b/lib/spurious/ruby/awssdk/strategy.rb
@@ -24,10 +24,6 @@ module Spurious
           Aws.config.update(:use_ssl => false, :s3_force_path_style => true)
         end
 
-        private
-
-        attr_reader :mapping
-
         def dynamo(port = true, ip = true)
           mapping["spurious-dynamo"] = {
             "port"       => port,
@@ -51,6 +47,10 @@ module Spurious
             "identifier" => "sqs"
           }
         end
+
+        private
+
+        attr_reader :mapping
       end
     end
   end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,1 +1,3 @@
 $: << File.join(File.dirname(__FILE__), "..", "lib")
+
+require "pry"

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,4 +1,1 @@
-$: << File.join(File.dirname(__FILE__), '..', 'lib')
-
-require 'spurious/ruby/awssdk/helper'
-require 'spurious/ruby/awssdk/strategy'
+$: << File.join(File.dirname(__FILE__), "..", "lib")

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -34,28 +34,24 @@ describe Spurious::Ruby::Awssdk::Strategy do
       subject.sqs
       subject.s3
 
-      expect(AWS).to receive(:config).exactly(7).times
+      expect(Aws).to receive(:config).exactly(7).times
       subject.apply(config)
-
     end
 
     it "only applys a subset of the options" do
       subject.dynamo(true, true)
 
-      expect(AWS).to receive(:config).exactly(3).times
+      expect(Aws).to receive(:config).exactly(3).times
       subject.apply(config)
-
     end
 
     it "only sets the port for one service" do
       subject.dynamo(true)
 
-      expect(AWS).to receive(:config).with(:dynamo_db_port => 314)
-      expect(AWS).to receive(:config).with(:dynamo_db_endpoint => "foo")
-      expect(AWS).to receive(:config).with({:use_ssl=>false, :s3_force_path_style=>true})
+      expect(Aws).to receive(:config).with(:dynamo_db_port => 314)
+      expect(Aws).to receive(:config).with(:dynamo_db_endpoint => "foo")
+      expect(Aws).to receive(:config).with({:use_ssl=>false, :s3_force_path_style=>true})
       subject.apply(config)
-
     end
-
   end
 end

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -1,29 +1,28 @@
-require 'helper'
+require "helper"
 
 describe Spurious::Ruby::Awssdk::Strategy do
-
   describe "#apply" do
     let(:config) {
       {
-        'spurious-sqs' => [
+        "spurious-sqs" => [
           {
-            'GuestPort' => 123,
-            'HostPort'  => 456,
-            'Host'      => 'foo'
+            "GuestPort" => 123,
+            "HostPort"  => 456,
+            "Host"      => "foo"
           }
         ],
-        'spurious-s3' => [
+        "spurious-s3" => [
           {
-            'GuestPort' => 789,
-            'HostPort'  => 101,
-            'Host'      => 'foo'
+            "GuestPort" => 789,
+            "HostPort"  => 101,
+            "Host"      => "foo"
           }
         ],
-        'spurious-dynamo' => [
+        "spurious-dynamo" => [
           {
-            'GuestPort' => 121,
-            'HostPort'  => 314,
-            'Host'      => 'foo'
+            "GuestPort" => 121,
+            "HostPort"  => 314,
+            "Host"      => "foo"
           }
         ]
       }

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -56,6 +56,14 @@ describe Spurious::Ruby::Awssdk::Strategy do
         subject.apply config
       end
     end
+
+    specify do
+      expect(mock_config).to receive(:update).with({
+        :use_ssl             => false,
+        :s3_force_path_style => true
+      }).once
+      subject.apply config
+    end
   end
 
   describe "#dynamo" do

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -33,7 +33,12 @@ describe Spurious::Ruby::Awssdk::Strategy do
       ]
     }
   end
-  let(:mock_config) { Hash.new }
+  let(:mock_config) do
+    instance_double(
+      "Hash",
+      :update => nil
+    )
+  end
   let(:set_all) { true }
 
   describe "#apply" do
@@ -63,6 +68,16 @@ describe Spurious::Ruby::Awssdk::Strategy do
         subject.apply config
       end
     end
+
+    specify do
+      expect(mock_config).to receive(:update).with(:dynamo_db_port => 314).once
+      subject.apply config
+    end
+
+    specify do
+      expect(mock_config).to receive(:update).with(:dynamo_db_endpoint => "foo").once
+      subject.apply config
+    end
   end
 
   describe "#s3" do
@@ -75,6 +90,16 @@ describe Spurious::Ruby::Awssdk::Strategy do
         subject.apply config
       end
     end
+
+    specify do
+      expect(mock_config).to receive(:update).with(:s3_port => 101).once
+      subject.apply config
+    end
+
+    specify do
+      expect(mock_config).to receive(:update).with(:s3_endpoint => "foo").once
+      subject.apply config
+    end
   end
 
   describe "#sqs" do
@@ -86,6 +111,16 @@ describe Spurious::Ruby::Awssdk::Strategy do
         expect(mock_config).to receive(:update).exactly(3).times
         subject.apply config
       end
+    end
+
+    specify do
+      expect(mock_config).to receive(:update).with(:sqs_port => 456).once
+      subject.apply config
+    end
+
+    specify do
+      expect(mock_config).to receive(:update).with(:sqs_endpoint => "foo").once
+      subject.apply config
     end
   end
 end

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -8,6 +8,31 @@ describe Spurious::Ruby::Awssdk::Strategy do
     allow(Aws).to receive(:config).with(no_args) { mock_config }
   end
 
+  let(:config) do
+    {
+      "spurious-sqs" => [
+        {
+          "GuestPort" => 123,
+          "HostPort"  => 456,
+          "Host"      => "foo"
+        }
+      ],
+      "spurious-s3" => [
+        {
+          "GuestPort" => 789,
+          "HostPort"  => 101,
+          "Host"      => "foo"
+        }
+      ],
+      "spurious-dynamo" => [
+        {
+          "GuestPort" => 121,
+          "HostPort"  => 314,
+          "Host"      => "foo"
+        }
+      ]
+    }
+  end
   let(:mock_config) { Hash.new }
   let(:set_all) { true }
 
@@ -26,21 +51,41 @@ describe Spurious::Ruby::Awssdk::Strategy do
         subject.apply config
       end
     end
+  end
 
-    it "only applys a subset of the options" do
-      subject.dynamo(true, true)
+  describe "#dynamo" do
+    let(:set_all) { false }
+    before { subject.dynamo(true, true) }
 
-      expect(Aws).to receive(:config).exactly(3).times
-      subject.apply(config)
+    context "sets ports just for this service" do
+      specify do
+        expect(mock_config).to receive(:update).exactly(3).times
+        subject.apply config
+      end
     end
+  end
 
-    it "only sets the port for one service" do
-      subject.dynamo(true)
+  describe "#s3" do
+    let(:set_all) { false }
+    before { subject.s3(true, true) }
 
-      expect(Aws).to receive(:config).with(:dynamo_db_port => 314)
-      expect(Aws).to receive(:config).with(:dynamo_db_endpoint => "foo")
-      expect(Aws).to receive(:config).with({:use_ssl=>false, :s3_force_path_style=>true})
-      subject.apply(config)
+    context "sets ports just for this service" do
+      specify do
+        expect(mock_config).to receive(:update).exactly(3).times
+        subject.apply config
+      end
+    end
+  end
+
+  describe "#sqs" do
+    let(:set_all) { false }
+    before { subject.sqs(true, true) }
+
+    context "sets ports just for this service" do
+      specify do
+        expect(mock_config).to receive(:update).exactly(3).times
+        subject.apply config
+      end
     end
   end
 end

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -1,40 +1,55 @@
 require "helper"
+require "spurious/ruby/awssdk/strategy"
 
 describe Spurious::Ruby::Awssdk::Strategy do
-  describe "#apply" do
-    let(:config) {
-      {
-        "spurious-sqs" => [
-          {
-            "GuestPort" => 123,
-            "HostPort"  => 456,
-            "Host"      => "foo"
-          }
-        ],
-        "spurious-s3" => [
-          {
-            "GuestPort" => 789,
-            "HostPort"  => 101,
-            "Host"      => "foo"
-          }
-        ],
-        "spurious-dynamo" => [
-          {
-            "GuestPort" => 121,
-            "HostPort"  => 314,
-            "Host"      => "foo"
-          }
-        ]
-      }
+  subject { described_class.new set_all }
+
+  before do
+    allow(Aws).to receive(:config).with(no_args) { mock_config }
+  end
+
+  let(:config) {
+    {
+      "spurious-sqs" => [
+        {
+          "GuestPort" => 123,
+          "HostPort"  => 456,
+          "Host"      => "foo"
+        }
+      ],
+      "spurious-s3" => [
+        {
+          "GuestPort" => 789,
+          "HostPort"  => 101,
+          "Host"      => "foo"
+        }
+      ],
+      "spurious-dynamo" => [
+        {
+          "GuestPort" => 121,
+          "HostPort"  => 314,
+          "Host"      => "foo"
+        }
+      ]
     }
+  }
+  let(:mock_config) { Hash.new }
+  let(:set_all) { true }
 
-    it "applys ports from config" do
-      subject.dynamo
-      subject.sqs
-      subject.s3
+  describe "#apply" do
+    context "applys ports to all services" do
+      specify do
+        expect(mock_config).to receive(:update).exactly(7).times
+        subject.apply config
+      end
+    end
 
-      expect(Aws).to receive(:config).exactly(7).times
-      subject.apply(config)
+    context "applys ports to 0 services" do
+      let(:set_all) { false }
+      specify do
+        expect(mock_config).to receive(:update).exactly(1).times
+        subject.apply config
+      end
     end
 
     it "only applys a subset of the options" do

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -8,31 +8,6 @@ describe Spurious::Ruby::Awssdk::Strategy do
     allow(Aws).to receive(:config).with(no_args) { mock_config }
   end
 
-  let(:config) {
-    {
-      "spurious-sqs" => [
-        {
-          "GuestPort" => 123,
-          "HostPort"  => 456,
-          "Host"      => "foo"
-        }
-      ],
-      "spurious-s3" => [
-        {
-          "GuestPort" => 789,
-          "HostPort"  => 101,
-          "Host"      => "foo"
-        }
-      ],
-      "spurious-dynamo" => [
-        {
-          "GuestPort" => 121,
-          "HostPort"  => 314,
-          "Host"      => "foo"
-        }
-      ]
-    }
-  }
   let(:mock_config) { Hash.new }
   let(:set_all) { true }
 

--- a/spurious-ruby-awssdk-helper.gemspec
+++ b/spurious-ruby-awssdk-helper.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rake-rspec", ">= 0.0.2"
 

--- a/spurious-ruby-awssdk-helper.gemspec
+++ b/spurious-ruby-awssdk-helper.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["stevenmajack@gmail.com"]
   spec.summary       = %q{Helper gem for configuring the AWS ruby SDK with spurious details}
   spec.description   = %q{Helper gem for configuring the AWS ruby SDK with spurious details}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/spurious-io/ruby-awssdk-helper"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/spurious-ruby-awssdk-helper.gemspec
+++ b/spurious-ruby-awssdk-helper.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rake-rspec", ">= 0.0.2"
 
-  spec.add_runtime_dependency "aws-sdk", "~> 1"
+  spec.add_runtime_dependency "aws-sdk", "~> 2"
 end


### PR DESCRIPTION
![https://media.giphy.com/media/QgixZj4y3TwnS/giphy.gif](https://media.giphy.com/media/QgixZj4y3TwnS/giphy.gif)

### Problem

The gem was pegged to using `v1` of the `aws-sdk` gem.

### Solution

- Update it.
- Refactored the tests for `::Strategy` as well

### Notes

- Major Release